### PR TITLE
Removed editor namespace from builds

### DIFF
--- a/Assets/SeuratCapture/Scripts/CaptureBuilder.cs
+++ b/Assets/SeuratCapture/Scripts/CaptureBuilder.cs
@@ -20,8 +20,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 using UnityEngine;
-using UnityEditor;
-using UnityEditor.SceneManagement;
 using System.Collections.Generic;
 using System.IO;
 

--- a/Assets/SeuratCapture/Scripts/CaptureHeadbox.cs
+++ b/Assets/SeuratCapture/Scripts/CaptureHeadbox.cs
@@ -23,8 +23,6 @@ using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
-using System.Collections.Generic;
-using System;
 using System.IO;
 
 public enum CubeFaceResolution
@@ -130,7 +128,14 @@ public class CaptureHeadbox : MonoBehaviour {
 
     string capture_output_folder = output_folder_;
     if (capture_output_folder.Length <= 0) {
+#if UNITY_EDITOR
       capture_output_folder = FileUtil.GetUniqueTempPathInProject();
+
+#else
+      Debug.LogError("No path was specified");
+      StopCapture();
+      return;
+#endif
     }
     Directory.CreateDirectory(capture_output_folder);
     capture_.BeginCapture(this, capture_output_folder, 1, new CaptureStatus());


### PR DESCRIPTION
Fixed issue with script compilation on build in Unity by removing unused namespaces and wrapping the FileUtil class 